### PR TITLE
update CDH version to 4.6.0 to solve leak in DFSClient (HDFS-5671)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.targetJdk>1.7</project.build.targetJdk>
         <shadeBase>com.facebook.presto.hadoop.shaded</shadeBase>
-        <dep.hadoop.version>2.0.0-cdh4.3.0</dep.hadoop.version>
+        <dep.hadoop.version>2.0.0-cdh4.6.0</dep.hadoop.version>
         <dep.slf4j.version>1.6.6</dep.slf4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,6 @@
                     <artifactId>commons-beanutils-core</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>commons-collections</groupId>
-                    <artifactId>commons-collections</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>commons-digester</groupId>
                     <artifactId>commons-digester</artifactId>
                 </exclusion>


### PR DESCRIPTION
[The socket leak in DFSInputStream](https://issues.apache.org/jira/browse/HDFS-5671) will cause a Presto node to finally run out of socket buffer space and freeze. [CDH 4.6.0](http://archive.cloudera.com/cdh4/cdh/4/hadoop-2.0.0-cdh4.6.0.CHANGES.txt) has included the patch for it. 